### PR TITLE
force maternity spells to be Other (Medical) treatment function

### DIFF
--- a/inputs_data/ip/baseline.py
+++ b/inputs_data/ip/baseline.py
@@ -16,6 +16,12 @@ def get_ip_baseline(spark: SparkSession) -> DataFrame:
     """
     return (
         get_ip_df(spark)
+        .withColumn(
+            "tretspef",
+            F.when(F.col("group") == "maternity", "Other (Medical)").otherwise(
+                F.col("tretspef")
+            ),
+        )
         .groupBy("fyear", "provider", "group", "tretspef")
         .agg(F.count("fyear").alias("count"))
         .withColumn("activity_type", F.lit("ip"))


### PR DESCRIPTION
temporary, until we implement #111. in the baseline table, force all maternity activity to appear under the "Other (Medical)" treatment function. The inputs app only shows this one specialty, so force all activity to appear under it.