### PR TITLE
switches the file we use for the migration_category variant

### DIFF
--- a/population_projections/get_ons_files_2022.py
+++ b/population_projections/get_ons_files_2022.py
@@ -71,9 +71,9 @@ def snpp_uri_variant_match(uri: str) -> str | None:
 
     match file:
         case "migcat23":
-            return "migration_category"
-        case "migcat":
             return None
+        case "migcat":
+            return "migration_category"
         case "5yr" | "5year":
             return "var_proj_5_year_migration"
         case "lowmig":


### PR DESCRIPTION
uses the file that uses the same local authority groupings as all the other variants