### PR TITLE
add script to generate day procedures code list

### DIFF
--- a/databricks_workflows/nhp_data-reference_data.yaml
+++ b/databricks_workflows/nhp_data-reference_data.yaml
@@ -53,6 +53,16 @@ resources:
           job_cluster_key: generate_nhp_reference
           libraries:
             - whl: ../dist/*.whl
+        - task_key: create_day_procedure_code_list
+          depends_on:
+            - task_key: create_provider_catchments
+          python_wheel_task:
+            package_name: nhp_data
+            entry_point: reference-day_procedures
+            parameters:
+              - "{{job.parameters.day_procedures_save_path}}"
+              - "{{job.parameters.day_procedures_base_year}}"
+          job_cluster_key: generate_nhp_reference
       job_clusters:
         - job_cluster_key: generate_nhp_reference
           new_cluster:
@@ -76,3 +86,7 @@ resources:
       parameters:
         - name: run_reference_data
           default: "True"
+        - name: day_procedures_save_path
+          default: /Volumes/nhp/reference/files/day_procedures.json
+        - name: day_procedures_base_year
+          default: "202324"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,9 @@ model_data-demographic_factors = "nhp.data.model_data.demographic_factors:main"
 model_data-ip = "nhp.data.model_data.ip:main"
 model_data-op = "nhp.data.model_data.op:main"
 
+reference-day_procedures = "nhp.data.reference.day_procedures:main"
 reference-ods_trusts = "nhp.data.reference.ods_trusts:main"
 reference-provider_main_icb = "nhp.data.reference.provider_main_icb:main"
 reference-population_by_imd_decile = "nhp.data.reference.population_by_imd_decile:main"
 reference-provider_catchments = "nhp.data.reference.provider_catchments:main"
+

--- a/src/nhp/data/model_data/health_status_adjustment/generate_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_gams.py
@@ -27,7 +27,7 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
                 for ds in ["ip", "op", "aae"]
             ],
         )
-        .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds"]))
+        .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))
         .filter(F.col("fyear").isin([2023]))
         .filter(F.col("age") >= 18)
     )

--- a/src/nhp/data/model_data/health_status_adjustment/generate_national_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_national_gams.py
@@ -24,7 +24,7 @@ def _get_data(spark: SparkSession, save_path: str) -> pd.DataFrame:
                 for ds in ["ip", "op", "aae"]
             ],
         )
-        .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds"]))
+        .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))
         .filter(F.col("fyear").isin([2023]))
     )
 

--- a/src/nhp/data/nhp_datasets/apc.py
+++ b/src/nhp/data/nhp_datasets/apc.py
@@ -28,6 +28,7 @@ hes_apc = (
     # ---
     .filter(F.col("sex").isin(["1", "2"]))
     .filter(F.col("age").between(0, 90))
+    .filter(F.col("speldur").isNotNull())
     .withColumn(
         "icb",
         # use the ccg of residence if available, otherwise use the ccg of responsibility

--- a/src/nhp/data/raw_data/inpatients.py
+++ b/src/nhp/data/raw_data/inpatients.py
@@ -61,7 +61,7 @@ def get_inpatients_data(spark: SparkSession) -> None:
                 & (F.col("classpat") == "2"),
                 "daycase",
             )
-            .otherwise(None),
+            .otherwise("unknown"),
         )
         .withColumn("is_wla", F.col("admimeth") == "11")
         .withColumn(
@@ -70,8 +70,6 @@ def get_inpatients_data(spark: SparkSession) -> None:
             .when(F.col("admimeth").startswith("3"), "maternity")
             .otherwise("non-elective"),
         )
-        .filter(F.col("speldur").isNotNull())
-        .filter(F.col("hsagrp").isNotNull())
         # add has_procedure column
         .join(
             apc_primary_procedures.select(

--- a/src/nhp/data/reference/day_procedures.py
+++ b/src/nhp/data/reference/day_procedures.py
@@ -1,0 +1,174 @@
+"""Generate a list of procedures that may be performed as day cases or outpatients"""
+
+import json
+import sys
+
+import pyspark.sql.functions as F
+from databricks.connect import DatabricksSession
+from pyspark.sql import DataFrame, SparkSession
+from scipy.stats import binomtest
+
+from nhp.data.nhp_datasets.apc import hes_apc
+from nhp.data.nhp_datasets.providers import read_data_with_provider
+
+
+def _get_procedures(spark: SparkSession, table_name: str) -> DataFrame:
+    return (
+        spark.read.table(f"hes.silver.{table_name}_procedures")
+        .filter(F.col("procedure_order") == 1)
+        .filter(~F.col("procedure_code").rlike("^O(1[1-46]|28|3[01346]|4[2-8]|5[23])"))
+        .filter(~F.col("procedure_code").rlike("^X[6-9]"))
+        .filter(~F.col("procedure_code").rlike("^[UYZ]"))
+    )
+
+
+def get_day_procedure_code_list(
+    spark: SparkSession,
+    base_year: int,
+    minimum_total: int = 100,
+    p_value: float = 0.001,
+) -> dict[str, list[str]]:
+    """_summary_
+
+    :param spark: The spark session to use
+    :type spark: SparkSession
+    :param base_year: Which year to filter the data to
+    :type base_year: int
+    :param minimum_total: what is the minimum number of procedures in total that must be performed,
+        defaults to 100
+    :type minimum_total: int, optional
+    :param p_value: what p-value to use when we run the binomial tests, defaults to 0.001
+    :type p_value: float, optional
+    :return: a dictionary containing the types and their code lists
+    :rtype: dict[str, list[str]]
+    """
+    P_USUALLY = 0.5
+    P_OCCASIONALLY = 0.05
+
+    providers = (
+        spark.read.table("strategyunit.reference.ods_trusts")
+        .filter(F.col("org_type").startswith("ACUTE"))
+        .select(F.col("org_to").alias("provider"))
+        .distinct()
+        .persist()
+    )
+
+    fyear_criteria = F.col("fyear") == base_year
+
+    op = (
+        # TODO: replicating logic from outpatients. not DRY.
+        # but, cannot use nhp.raw_data.opa as this table needs to created before
+        read_data_with_provider(spark, "hes.silver.opa")
+        .filter(F.col("sex").isin(["1", "2"]))
+        .filter(F.col("apptage").isNotNull())
+        # end of todo
+        .filter(F.col("atentype").isin(["1", "2"]))  # only include F2F appointments
+        .filter(
+            ~F.col("sushrg").rlike("^(WF|U)")
+        )  # only include appointments with a procedure
+        .join(providers, "provider", "semi")
+        .filter(fyear_criteria)
+    )
+
+    df_op = (
+        _get_procedures(spark, "opa")
+        .join(op, on=["fyear", "procode3", "attendkey"], how="semi")
+        .groupBy("procedure_code")
+        .agg(F.count("attendkey").alias("op"))
+    )
+
+    ip = (
+        hes_apc.join(providers, "provider", "semi")
+        .filter(fyear_criteria)
+        .filter(F.col("classpat").isin("1", "2"))
+        .filter(F.col("admimeth").startswith("1"))
+    )
+
+    df_ip = (
+        _get_procedures(spark, "apc")
+        .join(ip, on=["fyear", "procode3", "epikey"], how="inner")
+        .withColumn(
+            "type", F.when(F.col("classpat") == "1", F.lit("ip")).otherwise("dc")
+        )
+        .groupBy("procedure_code")
+        .pivot("type")
+        .count()
+    )
+
+    df = (
+        df_ip.join(df_op, "procedure_code", how="outer")
+        .fillna(0)
+        .withColumn("total", F.col("dc") + F.col("ip") + F.col("op"))
+        .filter(F.col("total") >= minimum_total)
+        .toPandas()
+        .melt(
+            id_vars=["procedure_code", "total"],
+            value_vars=["op", "dc"],
+            var_name="type",
+        )
+        .assign(
+            prob_usually=lambda x: x.apply(
+                lambda y: binomtest(
+                    y.value, y.total, p=P_USUALLY, alternative="greater"
+                ).pvalue,
+                axis=1,
+            )
+        )
+        .assign(
+            prob_occasionally=lambda x: x.apply(
+                lambda y: binomtest(
+                    y.value, y.total, p=P_OCCASIONALLY, alternative="greater"
+                ).pvalue,
+                axis=1,
+            )
+        )
+    )
+
+    usually_dc = set(
+        df.loc[(df.prob_usually < p_value) & (df.type == "dc"), "procedure_code"]
+    )
+    usually_op = set(
+        df.loc[(df.prob_usually < p_value) & (df.type == "op"), "procedure_code"]
+    )
+
+    occasionally_dc = (
+        set(
+            df.loc[
+                (df.prob_occasionally < p_value) & (df.type == "dc"), "procedure_code"
+            ]
+        )
+        - usually_dc
+        - usually_op
+    )
+    occasionally_op = (
+        set(
+            df.loc[
+                (df.prob_occasionally < p_value) & (df.type == "op"), "procedure_code"
+            ]
+        )
+        - usually_dc
+        - usually_op
+    )
+
+    return {
+        "usually_dc": sorted(list(usually_dc)),
+        "usually_op": sorted(list(usually_op)),
+        "occasionally_dc": sorted(list(occasionally_dc)),
+        "occasionally_op": sorted(list(occasionally_op)),
+    }
+
+
+def create_day_procedure_code_list(
+    spark: SparkSession, path: str, base_year: int
+) -> None:
+    day_procedure_code_list = get_day_procedure_code_list(spark, base_year)
+
+    with open(path, "w", encoding="UTF-8") as f:
+        json.dump(day_procedure_code_list, f)
+
+
+def main():
+    spark = DatabricksSession.builder.getOrCreate()
+    path = sys.argv[1]
+    base_year = int(sys.argv[2])
+    create_day_procedure_code_list(spark, path, base_year)


### PR DESCRIPTION
ensures that the day procedures code list is created in our pipeline. there are a few extra steps in order to make this work though. closes #25 

Essentially: this script requires the data for outpatients/inpatients to be ready during the reference step, but these aren't created until after the reference step. In order to get this to work we need to replicate the logic for filtering rows from inpatients/outpatients.

Inpatients is slightly easier, as there is already the `hes_apc` object created in `nhp_datasets`. Moved the additional filtering required into that layer (`speldur is not null`), and addressed a slight issue with the `hsagrp` column dropping `null` rows (created an explicit `"unknown"` group, but exclude them from the hsa gam calculation. There are negligable rows per year though that will fall into this category).

- **move speldur filter into hes_apc object**
- **changes logic for unknown hsagrps**
- **adds script for generating the day procedures code list**
- **updates reference workflow**

