### PR TITLE
fix duplicate age_group col in pop_by_imd_decile script

### DIFF
--- a/reference/population_by_imd_decile.py
+++ b/reference/population_by_imd_decile.py
@@ -16,7 +16,7 @@ def create_population_by_imd_decile(
     :type base_year: int, optional
     """
 
-    df = spark.read.table("nhp.default.apc")
+    df = spark.read.table("nhp.default.apc").drop("age_group")
 
     # create age group lookups
     age_groups = spark.createDataFrame(


### PR DESCRIPTION
Addition of age_group column into nhp.default.apc with https://github.com/The-Strategy-Unit/nhp_data/pull/166 has broken existing reference/population_by_imd_decile.py script. Fixes this bug