### PR TITLE
adds script to clean up spark files

### DIFF
--- a/databricks_workflows/nhp_data-extract_nhp_for_containers.yaml
+++ b/databricks_workflows/nhp_data-extract_nhp_for_containers.yaml
@@ -143,6 +143,17 @@ resources:
             - pypi:
                 package: pygam==0.9.1
             - whl: ../dist/*.whl
+        - task_key: clean_up
+          depends_on:
+            - task_key: generate_national_gams
+          python_wheel_task:
+            package_name: nhp_data
+            entry_point: model_data-clean_up
+            parameters:
+              - "{{job.parameters.save_path}}/{{job.parameters.data_version}}"
+          job_cluster_key: run_nhp_extracts_cluster
+          libraries:
+            - whl: ../dist/*.whl
       job_clusters:
         - job_cluster_key: run_nhp_extracts_cluster
           new_cluster:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ model_data-demographic_factors = "nhp.data.model_data.demographic_factors:main"
 model_data-inequalities = "nhp.data.model_data.inequalities:main"
 model_data-ip = "nhp.data.model_data.ip:main"
 model_data-op = "nhp.data.model_data.op:main"
+model_data-clean_up = "nhp.data.model_data.clean_up:main"
 
 reference-day_procedures = "nhp.data.reference.day_procedures:main"
 reference-ods_trusts = "nhp.data.reference.ods_trusts:main"

--- a/src/nhp/data/model_data/clean_up.py
+++ b/src/nhp/data/model_data/clean_up.py
@@ -1,0 +1,28 @@
+"""Clean up spark files.
+
+Removes any of the _SUCCESS, _committed_*, _started_* files that spark leaves."""
+
+import os
+import sys
+
+
+def clean_up(path: str) -> None:
+    """Clean up spark files from a given path.
+
+    :param path: the path to clean up
+    :type path: str
+    """
+    for dirpath, _, filenames in os.walk(path):
+        for filename in filenames:
+            if (
+                filename == "_SUCCESS"
+                or filename.startswith("_committed_")
+                or filename.startswith("_started_")
+            ):
+                full_path = os.path.join(dirpath, filename)
+                os.remove(full_path)
+
+
+def main() -> None:
+    path = sys.argv[1]
+    clean_up(path)


### PR DESCRIPTION
when we save the model data, we end up with a lot of extra files like \_SUCCESS, \_started\_\* and \_committed\_\*. These are internal for spark, but we do not need them in our final data storage. This script removes them.
