### PR TITLE
adds can manage permissions to the service principal

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -36,3 +36,5 @@ targets:
     permissions:
       - group_name: nhp_devs
         level: CAN_MANAGE
+      - service_principal_name: b61ef435-b155-42c7-8c9e-2a2442e280cd
+        level: CAN_MANAGE


### PR DESCRIPTION
needed for the generate data workflow to call the subworkflows
