### PR TITLE
properly counts op/a&e activity for HSA GAMs

### DIFF
--- a/databricks_workflows/nhp_data-extract_nhp_for_containers.yaml
+++ b/databricks_workflows/nhp_data-extract_nhp_for_containers.yaml
@@ -107,6 +107,7 @@ resources:
             entry_point: model_data-health_status_adjustment-generate_provider_gams
             parameters:
               - "{{job.parameters.data_version}}"
+              - "{{job.parameters.years}}"
           job_cluster_key: nhp_data
           libraries:
             - pypi:
@@ -120,6 +121,7 @@ resources:
             entry_point: model_data-health_status_adjustment-generate_icb_gams
             parameters:
               - "{{job.parameters.data_version}}"
+              - "{{job.parameters.years}}"
           job_cluster_key: nhp_data
           libraries:
             - pypi:
@@ -133,6 +135,7 @@ resources:
             entry_point: model_data-health_status_adjustment-generate_national_gams
             parameters:
               - "{{job.parameters.data_version}}"
+              - "{{job.parameters.years}}"
           job_cluster_key: nhp_data
           libraries:
             - pypi:

--- a/src/nhp/data/model_data/health_status_adjustment/generate_icb_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_icb_gams.py
@@ -1,5 +1,6 @@
 """Generate GAMs and HSA activity tables"""
 
+import json
 import sys
 from functools import reduce
 from typing import Any
@@ -8,14 +9,14 @@ import numpy as np
 import pandas as pd
 import pyspark.sql.functions as F
 from pygam import GAM
-from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import DataFrame, SparkSession, Window
 
 from nhp.data.get_spark import get_spark
 from nhp.data.model_data.helpers import create_icb_population_projections
 from nhp.data.table_names import table_names
 
 
-def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
+def _get_data(spark: SparkSession, save_path: str, years: list[int]) -> DataFrame:
     dfr = (
         reduce(
             DataFrame.unionByName,
@@ -38,7 +39,8 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
             ],
         )
         .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))
-        .filter(F.col("fyear").isin([2023]))
+        .filter(~F.col("hsagrp").startswith("op_maternity_"))
+        .filter(F.col("fyear").isin(years))
         .filter(F.col("age") >= 18)
     )
 
@@ -49,11 +51,20 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
         )
         .filter(F.col("variant") == "migration_category")
         .filter(F.col("age") >= 18)
-        .select(F.col("age"), F.col("sex"), F.col("icb"), F.col("2023").alias("pop"))
-        # join back to the unique combination of icb/sex/fyear/hsagrp, we
-        # will use this below to ensure we have a 0-count row of activity
+        .selectExpr(
+            "age",
+            "sex",
+            "icb",
+            "fyear as base_fyear",
+            f"stack({len(years)}, "
+            + ", ".join([f"'{y}', `{y}`" for y in years])
+            + ") as (fyear, pop)",
+        )
+        .filter(F.col("base_fyear") == F.col("fyear"))
+        .drop("base_fyear")
+        .withColumn("fyear", F.col("fyear").cast("int"))
         .join(
-            dfr.select("icb", "sex", "fyear", "hsagrp").distinct(),
+            dfr.select("icb", "sex", "hsagrp").distinct(),
             ["icb", "sex"],
             "inner",
         )
@@ -62,12 +73,27 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
     # generate the data. we right join to the demographics and fill the missing rows with 0's,
     # before calculating the activity rate as the amount of activity (count) divided by the
     # population.
-    return (
+    df = (
         dfr.join(demog, ["age", "sex", "icb", "hsagrp", "fyear"], "right")
         .fillna(0)
         .withColumn("activity_rate", F.col("count") / F.col("pop"))
         .drop("count", "pop")
     )
+
+    # remove any rows where all the activity rates are 0
+    w = Window.partitionBy("sex", "icb", "hsagrp", "fyear")
+    to_remove = (
+        df.withColumn(
+            "all_zero",
+            F.sum((F.col("activity_rate") == 0).cast("int")).over(w)
+            == F.count("activity_rate").over(w),
+        )
+        .filter(F.col("all_zero"))
+        .select("icb", "hsagrp", "sex", "fyear")
+        .distinct()
+    )
+
+    return df.join(to_remove, ["icb", "hsagrp", "sex", "fyear"], "anti")
 
 
 def _generate_gam(data: pd.DataFrame, progress: bool = False) -> Any:
@@ -139,10 +165,11 @@ def _generate_activity_tables(spark: SparkSession, all_gams: dict) -> None:
 def main() -> None:
     """Generate GAMs and HSA activity tables"""
     data_version = sys.argv[1]
+    years = [i // 100 for i in json.loads(sys.argv[2])]
     save_path = f"{table_names.model_data_path}/{data_version}"
 
     spark = get_spark()
 
-    dfr = _get_data(spark, save_path)
+    dfr = _get_data(spark, save_path, years)
     all_gams = _generate_gams(dfr)
     _generate_activity_tables(spark, all_gams)

--- a/src/nhp/data/model_data/health_status_adjustment/generate_icb_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_icb_gams.py
@@ -21,11 +21,20 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
             DataFrame.unionByName,
             [
                 (
-                    spark.read.parquet(f"{save_path}/{ds}")
+                    spark.read.parquet(f"{save_path}/ip")
                     .groupBy("fyear", "icb", "age", "sex", "hsagrp")
                     .count()
-                )
-                for ds in ["ip", "op", "aae"]
+                ),
+                (
+                    spark.read.parquet(f"{save_path}/op")
+                    .groupBy("fyear", "icb", "age", "sex", "hsagrp")
+                    .agg(F.sum("attendances").alias("count"))
+                ),
+                (
+                    spark.read.parquet(f"{save_path}/aae")
+                    .groupBy("fyear", "icb", "age", "sex", "hsagrp")
+                    .agg(F.sum("arrivals").alias("count"))
+                ),
             ],
         )
         .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))

--- a/src/nhp/data/model_data/health_status_adjustment/generate_national_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_national_gams.py
@@ -19,11 +19,20 @@ def _get_data(spark: SparkSession, save_path: str) -> pd.DataFrame:
             DataFrame.unionByName,
             [
                 (
-                    spark.read.parquet(f"{save_path}/{ds}")
+                    spark.read.parquet(f"{save_path}/ip")
                     .groupBy("fyear", "age", "sex", "hsagrp")
                     .count()
-                )
-                for ds in ["ip", "op", "aae"]
+                ),
+                (
+                    spark.read.parquet(f"{save_path}/op")
+                    .groupBy("fyear", "age", "sex", "hsagrp")
+                    .agg(F.sum("attendances").alias("count"))
+                ),
+                (
+                    spark.read.parquet(f"{save_path}/aae")
+                    .groupBy("fyear", "age", "sex", "hsagrp")
+                    .agg(F.sum("arrivals").alias("count"))
+                ),
             ],
         )
         .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))

--- a/src/nhp/data/model_data/health_status_adjustment/generate_national_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_national_gams.py
@@ -1,5 +1,8 @@
 """Generate GAMs and HSA activity tables"""
 
+import json
+import os
+import pickle as pkl
 import sys
 from functools import reduce
 
@@ -13,7 +16,7 @@ from nhp.data.get_spark import get_spark
 from nhp.data.table_names import table_names
 
 
-def _get_data(spark: SparkSession, save_path: str) -> pd.DataFrame:
+def _get_data(spark: SparkSession, save_path: str, years: list[int]) -> pd.DataFrame:
     dfr = (
         reduce(
             DataFrame.unionByName,
@@ -36,7 +39,7 @@ def _get_data(spark: SparkSession, save_path: str) -> pd.DataFrame:
             ],
         )
         .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))
-        .filter(F.col("fyear").isin([2023]))
+        .filter(F.col("fyear").isin(years))
     )
 
     # load the demographics data, then cross join to the distinct HSA groups
@@ -46,7 +49,7 @@ def _get_data(spark: SparkSession, save_path: str) -> pd.DataFrame:
         .filter(F.col("area_code").rlike("^E0[6-9]"))
         .filter(F.col("projection") == "migration_category")
         .filter(F.col("age") >= 18)
-        .filter(F.col("year") == 2023)
+        .filter(F.col("year").isin(years))
         .groupBy("age", "sex")
         .agg(F.sum("value").alias("pop"))
         .crossJoin(dfr.select("hsagrp").distinct())
@@ -66,8 +69,8 @@ def _get_data(spark: SparkSession, save_path: str) -> pd.DataFrame:
     )
 
 
-def _generate_gams(spark: SparkSession, save_path: str) -> dict:
-    dfr = _get_data(spark, save_path)
+def _generate_gams(spark: SparkSession, save_path: str, years: list[int]) -> dict:
+    dfr = _get_data(spark, save_path, years)
 
     # generate the GAMs as a nested dictionary by dataset/year/(HSA group, sex).
     # This may be amenable to some parallelisation? or other speed tricks possible with pygam?
@@ -81,6 +84,11 @@ def _generate_gams(spark: SparkSession, save_path: str) -> dict:
             for k, v in list(v2.groupby(["hsagrp", "sex"]))
         }
         all_gams["NATIONAL"][fyear] = g
+
+        path = f"{save_path}/hsa_gams/{fyear=}/dataset=NATIONAL"
+        os.makedirs(path, exist_ok=True)
+        with open(f"{path}/hsa_gams.pkl", "wb") as f:
+            pkl.dump(g, f)
     return all_gams
 
 
@@ -128,9 +136,10 @@ def _generate_activity_tables(spark: SparkSession, all_gams: dict) -> None:
 def main() -> None:
     """Generate GAMs and HSA activity tables"""
     data_version = sys.argv[1]
+    years = [i // 100 for i in json.loads(sys.argv[2])]
     save_path = f"{table_names.model_data_path}/{data_version}"
 
     spark = get_spark()
 
-    all_gams = _generate_gams(spark, save_path)
+    all_gams = _generate_gams(spark, save_path, years)
     _generate_activity_tables(spark, all_gams)

--- a/src/nhp/data/model_data/health_status_adjustment/generate_provider_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_provider_gams.py
@@ -22,11 +22,20 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
             DataFrame.unionByName,
             [
                 (
-                    spark.read.parquet(f"{save_path}/{ds}")
+                    spark.read.parquet(f"{save_path}/ip")
                     .groupBy("fyear", "dataset", "age", "sex", "hsagrp")
                     .count()
-                )
-                for ds in ["ip", "op", "aae"]
+                ),
+                (
+                    spark.read.parquet(f"{save_path}/op")
+                    .groupBy("fyear", "dataset", "age", "sex", "hsagrp")
+                    .agg(F.sum("attendances").alias("count"))
+                ),
+                (
+                    spark.read.parquet(f"{save_path}/aae")
+                    .groupBy("fyear", "dataset", "age", "sex", "hsagrp")
+                    .agg(F.sum("arrivals").alias("count"))
+                ),
             ],
         )
         .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))

--- a/src/nhp/data/model_data/health_status_adjustment/generate_provider_gams.py
+++ b/src/nhp/data/model_data/health_status_adjustment/generate_provider_gams.py
@@ -1,5 +1,6 @@
 """Generate GAMs and HSA activity tables"""
 
+import json
 import os
 import pickle as pkl
 import sys
@@ -10,13 +11,16 @@ import numpy as np
 import pandas as pd
 import pyspark.sql.functions as F
 from pygam import GAM
-from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import DataFrame, SparkSession, Window
 
 from nhp.data.get_spark import get_spark
 from nhp.data.table_names import table_names
 
 
-def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
+def _get_data(spark: SparkSession, save_path: str, years: list[int]) -> DataFrame:
+    # paeds hospitals
+    datasets_to_exclude = ["RBS", "RP4", "REP", "RQ3", "RAE"]
+
     dfr = (
         reduce(
             DataFrame.unionByName,
@@ -39,22 +43,31 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
             ],
         )
         .filter(~F.col("hsagrp").isin(["birth", "maternity", "paeds", "unknown"]))
-        .filter(F.col("fyear").isin([2023]))
+        .filter(~F.col("hsagrp").startswith("op_maternity_"))
+        .filter(~F.col("dataset").isin(datasets_to_exclude))
+        .filter(F.col("fyear").isin(years))
         .filter(F.col("age") >= 18)
     )
 
     # load the demographics data
     demog = (
-        spark.read.parquet(f"{save_path}/demographic_factors/fyear=2023/")
+        spark.read.parquet(f"{save_path}/demographic_factors/")
         .filter(F.col("variant") == "migration_category")
         .filter(F.col("age") >= 18)
-        .select(
-            F.col("age"), F.col("sex"), F.col("dataset"), F.col("2023").alias("pop")
+        .selectExpr(
+            "age",
+            "sex",
+            "dataset",
+            "fyear as base_fyear",
+            f"stack({len(years)}, "
+            + ", ".join([f"'{y}', `{y}`" for y in years])
+            + ") as (fyear, pop)",
         )
-        # join back to the unique combination of dataset/sex/fyear/hsagrp, we
-        # will use this below to ensure we have a 0-count row of activity
+        .filter(F.col("base_fyear") == F.col("fyear"))
+        .drop("base_fyear")
+        .withColumn("fyear", F.col("fyear").cast("int"))
         .join(
-            dfr.select("dataset", "sex", "fyear", "hsagrp").distinct(),
+            dfr.select("dataset", "sex", "hsagrp").distinct(),
             ["dataset", "sex"],
             "inner",
         )
@@ -63,12 +76,27 @@ def _get_data(spark: SparkSession, save_path: str) -> DataFrame:
     # generate the data. we right join to the demographics and fill the missing rows with 0's,
     # before calculating the activity rate as the amount of activity (count) divided by the
     # population.
-    return (
+    df = (
         dfr.join(demog, ["age", "sex", "dataset", "hsagrp", "fyear"], "right")
         .fillna(0)
         .withColumn("activity_rate", F.col("count") / F.col("pop"))
         .drop("count", "pop")
     )
+
+    # remove any rows where all the activity rates are 0
+    w = Window.partitionBy("sex", "dataset", "hsagrp", "fyear")
+    to_remove = (
+        df.withColumn(
+            "all_zero",
+            F.sum((F.col("activity_rate") == 0).cast("int")).over(w)
+            == F.count("activity_rate").over(w),
+        )
+        .filter(F.col("all_zero"))
+        .select("dataset", "hsagrp", "sex", "fyear")
+        .distinct()
+    )
+
+    return df.join(to_remove, ["dataset", "hsagrp", "sex", "fyear"], "anti")
 
 
 def _generate_gam(data: pd.DataFrame, progress: bool = False) -> Any:
@@ -102,7 +130,7 @@ def _generate_gams(save_path: str, spark_df: DataFrame) -> dict:
 
 
 def _generate_activity_tables(
-    spark: SparkSession, save_path: str, all_gams: dict
+    spark: SparkSession, save_path: str, all_gams: dict, years: list[int]
 ) -> None:
     # Generate activity tables
     #
@@ -150,8 +178,8 @@ def _generate_activity_tables(
 
     (
         spark.read.table(table_names.default_hsa_activity_tables_provider)
-        .filter(F.col("fyear").isin([202324]))
         .withColumn("fyear", F.udf(from_fyear)("fyear"))
+        .filter(F.col("fyear").isin(years))
         .withColumnRenamed("provider", "dataset")
         .repartition(1)
         .write.mode("overwrite")
@@ -163,10 +191,11 @@ def _generate_activity_tables(
 def main() -> None:
     """Generate GAMs and HSA activity tables"""
     data_version = sys.argv[1]
+    years = [i // 100 for i in json.loads(sys.argv[2])]
     save_path = f"{table_names.model_data_path}/{data_version}"
 
     spark = get_spark()
 
-    dfr = _get_data(spark, save_path)
+    dfr = _get_data(spark, save_path, years)
     all_gams = _generate_gams(save_path, dfr)
-    _generate_activity_tables(spark, save_path, all_gams)
+    _generate_activity_tables(spark, save_path, all_gams, years)


### PR DESCRIPTION
resolves #247 - outpatient and A&E gams are now using the correct sum of activity

resolves #221 - make sure we only generate GAMs where there is some data (there could be cases where a provider didn't have any activity at all for some of the `hsagrp`s). also excludes paeds hospitals because they should never have gams generated (filter for age >= 18)

resolves #204 - allows us to generate gams for multiple years
