### PR TITLE
removes the dataset column from saved ip file

### DIFF
--- a/src/nhp/data/model_data/generate_synthetic_data.py
+++ b/src/nhp/data/model_data/generate_synthetic_data.py
@@ -124,7 +124,6 @@ class SynthData:
                 "dataset",
                 "sitetret",
             )
-            .withColumn("dataset", F.lit("synthetic"))
             .withColumn("icb", F.when(F.col("is_main_icb"), "A").otherwise("B"))
             .withColumn("mainspef", F.col("tretspef"))
             .filter(~F.col("tretspef_grouped").startswith("Other"))

--- a/src/nhp/data/raw_data/inpatients.py
+++ b/src/nhp/data/raw_data/inpatients.py
@@ -81,7 +81,8 @@ def get_inpatients_data(spark: SparkSession) -> DataFrame:
                     F.col("admimeth").startswith("3")
                     | F.col("mainspef").isin(["501", "560"])
                 )
-                & (F.col("age") < 56),
+                & (F.col("age").between(13, 55))
+                & (F.col("sex") == "2"),
                 "maternity",
             )
             .when(F.col("admimeth").startswith("2"), "emerg")


### PR DESCRIPTION
dataset is in the partition, so not needed in the the parquet file. infact, this causes the parquet files to be unreadable because of the duplicated column definition
