### PR TITLE
removes susspellid from synth data

### DIFF
--- a/src/nhp/data/model_data/generate_synthetic_data.py
+++ b/src/nhp/data/model_data/generate_synthetic_data.py
@@ -106,7 +106,7 @@ class SynthData:
             self.read_dev_file("ip")
             .drop(
                 "procode3",
-                "susspelllid",
+                "susspellid",
                 "person_id",
                 "admiage",
                 "admidate",

--- a/src/nhp/data/model_data/generate_synthetic_data.py
+++ b/src/nhp/data/model_data/generate_synthetic_data.py
@@ -106,6 +106,7 @@ class SynthData:
             self.read_dev_file("ip")
             .drop(
                 "procode3",
+                "susspelllid",
                 "person_id",
                 "admiage",
                 "admidate",


### PR DESCRIPTION
this column isn't needed for testing the model, and only risks disclosure from inclusion. if it is needed in the future then we could simply reuse the rn column which is recreated and is non-disclosive
